### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:22.04
+
+# Install system dependencies and cleanup
+RUN apt-get update && apt-get install -y \
+    tesseract-ocr \
+    tesseract-ocr-eng \
+    libtesseract-dev \
+    libleptonica-dev \
+    python3 \
+    python3-pip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Copy requirements file
+COPY requirements.txt .
+
+# Install Python dependencies including propeller
+RUN pip3 install -r requirements.txt
+
+# Copy application files
+COPY . .
+
+# Environment variables for Tesseract
+ENV TESSDATA_PREFIX=/usr/share/tesseract-ocr/4.00/tessdata
+
+# Expose port 8080
+EXPOSE 8080
+
+# Default command
+CMD ["python3", "-m", "http.server", "8080"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ python-dotenv==1.0.1
 python-multipart==0.0.17
 tiktoken==0.8.0
 uvicorn==0.32.0
+propeller-lib==0.0.3


### PR DESCRIPTION
# Docker Setup for Resume Parser

This Docker container runs on a Linux distribution with all necessary dependencies, including Tesseract and Propellor. Since Ubuntu does not have Propellor by default, I have added it to the requirements.

## Build the Docker Image

To build the Docker image, run the following command:

```bash
docker build -t resume-parser .
